### PR TITLE
Fixed a bug in the frequency array in mjo_cross.

### DIFF
--- a/tropical_diagnostics/spacetime.py
+++ b/tropical_diagnostics/spacetime.py
@@ -399,7 +399,12 @@ def mjo_cross(X, Y, segLen, segOverLap, opt=False):
     # initialize spectrum array
     STC = np.zeros([8, nfreq, nwave], dtype='double')
     wave = np.arange(-int(nwave / 2), int(nwave / 2) + 1, 1.)
-    freq = np.linspace(0, 0.5, num=nfreq)
+    if segLen % 2 == 1:
+        #nfreq = int((ntim+1)/2)
+        freq = np.linspace(0, 0.5*(segLen-1)/segLen, num=nfreq)
+    else:
+        #nfreq = int(ntim/2) + 1
+        freq = np.linspace(0, 0.5, num=nfreq)
 
     # find time-mean index
     indfreq0 = np.where(freq == 0.)[0]


### PR DESCRIPTION
For the real valued fft (np.fft.fftr2) the frequency range changes if the number of time values is odd or even. The Nyquist frequency is only part of the frequency array when the number of times is even.